### PR TITLE
Hide @api_token when object is inspected

### DIFF
--- a/lib/openai/chat.rb
+++ b/lib/openai/chat.rb
@@ -66,5 +66,9 @@ module OpenAI
   
       schema.present? ? JSON.parse(content) : content
     end
+
+    def inspect
+      "#<#{self.class.name} @messages=#{messages.inspect} @model=#{@model.inspect} @schema=#{@schema.inspect}>"
+    end
   end
 end


### PR DESCRIPTION
Resolves #2 

### Problem

Currently, the API token appears in the inspected object after a `.new`.

### Solution

This commit adds an override to the inspect method that hides the value of `@api_token`.

The inspect now looks like:

```rb
#<OpenAI::Chat:1740 @messages=[] @model="gpt-4o" @schema=nil>
```

[link](https://thoughtbot.com/blog/ruby-inspect-tutorial)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Overrides `inspect` in `OpenAI::Chat` to hide `@api_token`, enhancing security by preventing token exposure.
> 
>   - **Behavior**:
>     - Overrides `inspect` method in `OpenAI::Chat` to exclude `@api_token` from output.
>     - `inspect` now shows `@messages`, `@model`, and `@schema` only.
>   - **Security**:
>     - Prevents exposure of `@api_token` in object inspection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fopenai-chat&utm_source=github&utm_medium=referral)<sup> for d68c0322c908c265903aa571e7c91d8075c26d07. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->