### PR TITLE
Replace gem dependencies with standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,6 @@
 
 ## [0.0.2] - 2025-02-28
 
-- Gem dependencies are now open-ended.
+- All dependencies have been removed
+- Supports Ruby 2.0.0
+- Updates gem author

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## [0.0.1] - 2025-02-27
 
 - Initial release
+
+## [0.0.2] - 2025-02-28
+
+- Gem dependencies are now open-ended.

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ source "https://rubygems.org"
 gemspec
 
 gem "activesupport", ">= 2.3.5"
-gem "http",">= 5.2.0"
-gem "json",">= 2.6.0"
+gem "http", ">= 5.2.0"
+gem "json", ">= 2.6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in draft_chat.gemspec
 gemspec
 
-gem "activesupport", "~> 2.3", ">= 2.3.5"
-gem "http", "~> 5.2", ">= 5.2.0"
-gem "json", "~> 2.6", ">= 2.6.0"
+gem "activesupport", ">= 2.3.5"
+gem "http",">= 5.2.0"
+gem "json",">= 2.6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in draft_chat.gemspec
 gemspec
-
-gem "activesupport", ">= 2.3.5"
-gem "http", ">= 5.2.0"
-gem "json", ">= 2.6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in draft_chat.gemspec
 gemspec
 
-gem "activesupport", ">= 2.3.5"
-gem "http", ">= 5.2.0"
-gem "json", ">= 2.6.0"
+gem "activesupport", "~> 2.3", ">= 2.3.5"
+gem "http", "~> 5.2", ">= 5.2.0"
+gem "json", "~> 2.6", ">= 2.6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,19 @@
 PATH
   remote: .
   specs:
-    draft_chat (0.0.1)
-      http (>= 5.2.0)
-      json (>= 2.6.0)
+    openai-chat (0.0.1)
+      activesupport (~> 2.3, >= 2.3.5)
+      http (~> 5.2, >= 5.2.0)
+      json (~> 2.6, >= 2.6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.2.1)
-      base64
-      benchmark (>= 0.3)
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
+    activesupport (2.3.18)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
-    benchmark (0.4.0)
-    bigdecimal (3.1.9)
-    concurrent-ruby (1.3.5)
-    connection_pool (2.5.0)
     domain_name (0.6.20240107)
-    drb (2.2.1)
     ffi (1.17.1)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
@@ -42,28 +27,21 @@ GEM
     http-cookie (1.0.8)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    i18n (1.14.7)
-      concurrent-ruby (~> 1.0)
     json (2.10.1)
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    logger (1.6.6)
-    minitest (5.25.4)
     public_suffix (6.0.1)
     rake (13.2.1)
-    securerandom (0.4.1)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
 
 PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activesupport (>= 2.3.5)
-  draft_chat!
-  http (>= 5.2.0)
-  json (>= 2.6.0)
+  activesupport (~> 2.3, >= 2.3.5)
+  http (~> 5.2, >= 5.2.0)
+  json (~> 2.6, >= 2.6.0)
+  openai-chat!
 
 BUNDLED WITH
    2.3.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    openai-chat (0.0.1)
-      activesupport (~> 2.3, >= 2.3.5)
-      http (~> 5.2, >= 5.2.0)
-      json (~> 2.6, >= 2.6.0)
+    openai-chat (0.0.2)
+      activesupport (>= 2.3.5)
+      http (>= 5.2.0)
+      json (>= 2.6.0)
 
 GEM
   remote: https://rubygems.org/
@@ -38,9 +38,9 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activesupport (~> 2.3, >= 2.3.5)
-  http (~> 5.2, >= 5.2.0)
-  json (~> 2.6, >= 2.6.0)
+  activesupport (>= 2.3.5)
+  http (>= 5.2.0)
+  json (>= 2.6.0)
   openai-chat!
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,45 +2,15 @@ PATH
   remote: .
   specs:
     openai-chat (0.0.2)
-      activesupport (>= 2.3.5)
-      http (>= 5.2.0)
-      json (>= 2.6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (2.3.18)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
-    base64 (0.2.0)
-    domain_name (0.6.20240107)
-    ffi (1.17.1)
-    ffi-compiler (1.3.2)
-      ffi (>= 1.15.5)
-      rake
-    http (5.2.0)
-      addressable (~> 2.8)
-      base64 (~> 0.1)
-      http-cookie (~> 1.0)
-      http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.5.0)
-    http-cookie (1.0.8)
-      domain_name (~> 0.5)
-    http-form_data (2.3.0)
-    json (2.10.1)
-    llhttp-ffi (0.5.0)
-      ffi-compiler (~> 1.0)
-      rake (~> 13.0)
-    public_suffix (6.0.1)
-    rake (13.2.1)
 
 PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activesupport (>= 2.3.5)
-  http (>= 5.2.0)
-  json (>= 2.6.0)
   openai-chat!
 
 BUNDLED WITH

--- a/lib/openai/chat.rb
+++ b/lib/openai/chat.rb
@@ -1,31 +1,30 @@
 # frozen_string_literal: true
 
 require "openai/chat/version"
+require "net/http"
+require "uri"
+require "json"
 
 module OpenAI
   class Chat
-    require "active_support/core_ext/object/blank"
-    require "http"
-    require "json"
-  
     attr_accessor :messages, :schema, :model
-  
+
     def initialize(api_token: nil)
       @api_token = api_token || ENV.fetch("OPENAI_TOKEN")
       @messages = []
       @model = "gpt-4o"
     end
-  
+
     def system(content)
-      messages.push({role: "system", content:})
+      messages.push({role: "system", content: content})
     end
-  
+
     def user(content)
-      messages.push({role: "user", content:})
+      messages.push({role: "user", content: content})
     end
 
     def assistant(content)
-      messages.push({role: "assistant", content:})
+      messages.push({role: "assistant", content: content})
     end
 
     def assistant!
@@ -33,38 +32,40 @@ module OpenAI
         "Authorization" => "Bearer #{@api_token}",
         "content-type" => "application/json",
       }
-  
-      response_format = if schema.present?
+
+      response_format = if schema.nil?
+        {
+          "type" => "text"
+        }
+      else
         {
           "type" => "json_schema",
           "json_schema" => JSON.parse(schema)
         }
-      else
-        {
-          "type" => "text"
-        }
       end
-  
+
       request_body_hash = {
         "model" => model,
         "response_format" => response_format,
         "messages" => messages
       }
-  
+
       request_body_json = JSON.generate(request_body_hash)
-  
-      raw_response = HTTP.headers(request_headers_hash).post(
-        "https://api.openai.com/v1/chat/completions",
-        :body => request_body_json,
-      ).to_s
-  
-      parsed_response = JSON.parse(raw_response)
-  
+
+      uri = URI("https://api.openai.com/v1/chat/completions")
+      raw_response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        request = Net::HTTP::Post.new(uri, request_headers_hash)
+        request.body = request_body_json
+        http.request(request)
+      end
+
+      parsed_response = JSON.parse(raw_response.body)
+
       content = parsed_response.fetch("choices").at(0).fetch("message").fetch("content")
-  
-      messages.push({role: "assistant", content:})
-  
-      schema.present? ? JSON.parse(content) : content
+
+      messages.push({role: "assistant", content: content})
+
+      schema.nil? ? content : JSON.parse(content)
     end
 
     def inspect

--- a/lib/openai/chat/version.rb
+++ b/lib/openai/chat/version.rb
@@ -2,6 +2,6 @@
 
 module OpenAI
   class Chat
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end

--- a/openai_chat.gemspec
+++ b/openai_chat.gemspec
@@ -30,9 +30,9 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "activesupport", ">= 2.3.5"
-  spec.add_runtime_dependency "http", ">= 5.2.0"
-  spec.add_runtime_dependency "json", ">= 2.6.0"
+  spec.add_runtime_dependency "activesupport", "~> 2.3", ">= 2.3.5"
+  spec.add_runtime_dependency "http", "~> 5.2", ">= 5.2.0"
+  spec.add_runtime_dependency "json", "~> 2.6", ">= 2.6.0"
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"

--- a/openai_chat.gemspec
+++ b/openai_chat.gemspec
@@ -5,8 +5,8 @@ require_relative "lib/openai/chat/version"
 Gem::Specification.new do |spec|
   spec.name = "openai-chat"
   spec.version = OpenAI::Chat::VERSION
-  spec.authors = ["Jelani Woods"]
-  spec.email = ["jelani@firstdraft.com"]
+  spec.authors = ["Raghu Betina", "Jelani Woods"]
+  spec.email = ["raghu@firstdraft.com", "jelani@firstdraft.com"]
 
   spec.summary = "This gem provides a class called `OpenAI::Chat` that is intended to make it as easy as possible to use OpenAI's Chat Completions endpoint."
   spec.description = "This gem provides a class called `OpenAI::Chat` that is intended to make it as easy as possible to use OpenAI's Chat Completions endpoint. Supports Structured Output."

--- a/openai_chat.gemspec
+++ b/openai_chat.gemspec
@@ -30,9 +30,9 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "activesupport", "~> 2.3", ">= 2.3.5"
-  spec.add_runtime_dependency "http", "~> 5.2", ">= 5.2.0"
-  spec.add_runtime_dependency "json", "~> 2.6", ">= 2.6.0"
+  spec.add_runtime_dependency "activesupport", ">= 2.3.5"
+  spec.add_runtime_dependency "http", ">= 5.2.0"
+  spec.add_runtime_dependency "json", ">= 2.6.0"
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"

--- a/openai_chat.gemspec
+++ b/openai_chat.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "This gem provides a class called `OpenAI::Chat` that is intended to make it as easy as possible to use OpenAI's Chat Completions endpoint. Supports Structured Output."
   spec.homepage = "https://github.com/firstdraft/openai-chat"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 1.6.7"
+  spec.required_ruby_version = ">= 2.0.0"
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 

--- a/openai_chat.gemspec
+++ b/openai_chat.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "This gem provides a class called `OpenAI::Chat` that is intended to make it as easy as possible to use OpenAI's Chat Completions endpoint. Supports Structured Output."
   spec.homepage = "https://github.com/firstdraft/openai-chat"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 1.6.7"
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 
@@ -30,9 +30,6 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "activesupport", ">= 2.3.5"
-  spec.add_runtime_dependency "http", ">= 5.2.0"
-  spec.add_runtime_dependency "json", ">= 2.6.0"
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"


### PR DESCRIPTION
Resolves #4 

Current gem dependency requirements are too strict and make it difficult to install.

This commit replaces gem dependencies with features available in the standard library.

- The required Ruby version is set to `2.0.0+`.
- Gem version minor bump
- Gem author update

---

You can test this branch by installing the gem within a [rails-7-template](https://github.com/appdev-projects/rails-7-template) app.

```
gem "openai-chat", github: "firstdraft/openai-chat", branch: "4-make-gem-dependencies-flexible"
```

You can test using the gem if you have an API token handy by following the [example in the README](https://github.com/firstdraft/openai-chat?tab=readme-ov-file#openaichat)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaced gem dependencies with standard library features, updated Ruby version requirement, and modified author information.
> 
>   - **Dependencies**:
>     - Removed `activesupport`, `http`, and `json` gem dependencies from `Gemfile` and `openai_chat.gemspec`.
>     - Replaced with standard library features in `lib/openai/chat.rb` using `net/http`, `uri`, and `json`.
>   - **Ruby Version**:
>     - Updated required Ruby version to `>= 2.0.0` in `openai_chat.gemspec`.
>   - **Misc**:
>     - Updated gem author information in `openai_chat.gemspec`.
>     - Incremented version to `0.0.2` in `lib/openai/chat/version.rb` and `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fopenai-chat&utm_source=github&utm_medium=referral)<sup> for 5037d2cb7a488c9b429aef7d804444529d3b9696. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->