### PR TITLE
Add support for images

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--format documentation
+--color

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,11 @@
+ruby_version: 2.0
+fix: true
+parallel: true
+
+ignore:
+  - 'vendor/**/*'
+  - 'spec/fixtures/**/*'
+  - 'spec/vcr_cassettes/**/*'
+  - '*.md'
+  - '*.markdown'
+  - 'LICENSE*'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,16 +2,128 @@ PATH
   remote: .
   specs:
     openai-chat (0.0.2)
+      mime-types (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (8.0.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    ast (2.4.2)
+    base64 (0.2.0)
+    benchmark (0.4.0)
+    bigdecimal (3.1.9)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.0)
+    crack (1.0.0)
+      bigdecimal
+      rexml
+    diff-lcs (1.6.0)
+    drb (2.2.1)
+    factory_bot (6.5.1)
+      activesupport (>= 6.1.0)
+    hashdiff (1.1.2)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    json (2.10.1)
+    language_server-protocol (3.17.0.4)
+    lint_roller (1.1.0)
+    logger (1.6.6)
+    mime-types (3.6.0)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2025.0304)
+    minitest (5.25.4)
+    parallel (1.26.3)
+    parser (3.3.7.1)
+      ast (~> 2.4.1)
+      racc
+    public_suffix (6.0.1)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.10.0)
+    rexml (3.4.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.3)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
+    rubocop (1.69.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.36.2, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.38.1)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.23.0)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
+    standard (1.43.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.69.1)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.6)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.6.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.23.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
+    uri (1.0.3)
+    vcr (6.3.1)
+      base64
+    webmock (3.25.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
+  factory_bot (~> 6.2)
   openai-chat!
+  rake (~> 13.0)
+  rspec (~> 3.12)
+  standard (~> 1.32)
+  vcr (~> 6.1)
+  webmock (~> 3.18)
 
 BUNDLED WITH
    2.3.7

--- a/README.md
+++ b/README.md
@@ -2,51 +2,6 @@
 
 This gem provides a class called `OpenAI::Chat` that is intended to make it as easy as possible to use OpenAI's Chat Completions endpoint.
 
-For example:
-
-```ruby
-x = OpenAI::Chat.new
-x.system("You are a helpful assistant that speaks like Shakespeare.")
-x.user("Hi there!")
-x.assistant!
-# => "Greetings, good sir or madam! How dost thou fare on this fine day? Pray, tell me how I may be of service to thee."
-
-x.user("What's the best pizza in Chicago?")
-x.assistant!
-# => "Ah, the fair and bustling city of Chicago, renowned for its deep-dish delight that hath captured hearts and stomachs aplenty. Amongst the many offerings of this great city, 'tis often said that Lou Malnati's and Giordano's art the titans of the deep-dish realm. Lou Malnati's crust is praised for its buttery crispness, whilst Giordano's doth boast a stuffed creation that is nigh unto legendary. Yet, I encourage thee to embark upon thine own quest and savor the offerings of these famed establishments, for in the tasting lies the truth of which thy palate prefers. Enjoy the gastronomic adventure, my friend."
-```
-
-Or, with Structured Output (I suggest using [OpenAI's handy tool for generating the JSON Schema](https://platform.openai.com/docs/guides/structured-outputs)):
-
-```ruby
-x = OpenAI::Chat.new
-x.system("You are an expert nutritionist. The user will describe a meal. Estimate the calories, carbs, fat, and protein.")
-x.schema = '{"name": "nutrition_values","strict": true,"schema": {"type": "object","properties": {  "fat": {    "type": "number",    "description": "The amount of fat in grams."  },  "protein": {    "type": "number",    "description": "The amount of protein in grams."  },  "carbs": {    "type": "number",    "description": "The amount of carbohydrates in grams."  },  "total_calories": {    "type": "number",    "description": "The total calories calculated based on fat, protein, and carbohydrates."  }},"required": [  "fat",  "protein",  "carbs",  "total_calories"],"additionalProperties": false}}'
-x.user("1 slice of pizza")
-x.assistant!
-# => {"fat"=>15, "protein"=>5, "carbs"=>50, "total_calories"=>350}
-```
-
-More details:
-
-- By default, the gem assumes you have an environment variable called exactly `OPENAI_TOKEN`. If not, you can also provide your token when instantiating a chat:
-
-    ```ruby
-    x = OpenAI::Chat.new(api_token: "your-token-goes-here")
-    ```
-- By default, the gem uses the `gpt-4o` model. If you want something else, you can set it:
-
-    ```ruby
-    x.model = "o3-mini"
-    ```
-- You can call `.messages` to get an array containing the conversation so far.
-- You can manually set the assistant message
-    ```rb
-    x.assistant("Greetings, good sir or madam! How dost thou fare on this fine day? Pray, tell me how I may be of service to thee.")
-    ```
-
-Enjoy!
-
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -67,10 +22,112 @@ Or, install it directly with:
 gem install openai-chat
 ```
 
+## Configuration
+
+- By default, the gem assumes you have an environment variable called exactly `OPENAI_TOKEN`. If not, you can also provide your token when instantiating a chat:
+
+    ```ruby
+    x = OpenAI::Chat.new(api_token: "your-token-goes-here")
+    ```
+- By default, the gem uses the `gpt-4o` model. If you want something else, you can set it:
+
+    ```ruby
+    x.model = "o3-mini"
+    ```
+
+## Simplest usage
+
+```ruby
+x = OpenAI::Chat.new
+x.system("You are a helpful assistant that speaks like Shakespeare.")
+x.user("Hi there!")
+x.assistant!
+# => "Greetings, good sir or madam! How dost thou fare on this fine day? Pray, tell me how I may be of service to thee."
+
+x.user("What's the best pizza in Chicago?")
+x.assistant!
+# => "Ah, the fair and bustling city of Chicago, renowned for its deep-dish delight that hath captured hearts and stomachs aplenty. Amongst the many offerings of this great city, 'tis often said that Lou Malnati's and Giordano's art the titans of the deep-dish realm. Lou Malnati's crust is praised for its buttery crispness, whilst Giordano's doth boast a stuffed creation that is nigh unto legendary. Yet, I encourage thee to embark upon thine own quest and savor the offerings of these famed establishments, for in the tasting lies the truth of which thy palate prefers. Enjoy the gastronomic adventure, my friend."
+```
+
+## Structured Output
+
+Get back Structured Output by setting the `schema` attribute (I suggest using [OpenAI's handy tool for generating the JSON Schema](https://platform.openai.com/docs/guides/structured-outputs)):
+
+```ruby
+x = OpenAI::Chat.new
+x.system("You are an expert nutritionist. The user will describe a meal. Estimate the calories, carbs, fat, and protein.")
+x.schema = '{"name": "nutrition_values","strict": true,"schema": {"type": "object","properties": {  "fat": {    "type": "number",    "description": "The amount of fat in grams."  },  "protein": {    "type": "number",    "description": "The amount of protein in grams."  },  "carbs": {    "type": "number",    "description": "The amount of carbohydrates in grams."  },  "total_calories": {    "type": "number",    "description": "The total calories calculated based on fat, protein, and carbohydrates."  }},"required": [  "fat",  "protein",  "carbs",  "total_calories"],"additionalProperties": false}}'
+x.user("1 slice of pizza")
+x.assistant!
+# => {"fat"=>15, "protein"=>5, "carbs"=>50, "total_calories"=>350}
+```
+
+## Include images
+
+You can include images in your chat messages using the `user` method with the `image` or `images` parameter:
+
+```ruby
+# Send a single image
+x.user("What's in this image?", image: "path/to/local/image.jpg")
+
+# Send multiple images
+x.user("What are these images showing?", images: ["path/to/image1.jpg", "https://example.com/image2.jpg"])
+```
+
+The gem supports three types of image inputs:
+
+- URLs: Pass an image URL starting with `http://` or `https://`.
+- File paths: Pass a string with a path to a local image file.
+- File-like objects: Pass an object that responds to `read` (like `File.open("image.jpg")` or a Rails uploaded file).
+
+You can send multiple images, and place them between bits of text, in a single user message:
+
+```ruby
+z = OpenAI::Chat.new
+z.user(
+  [
+    {"image" => "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Eubalaena_glacialis_with_calf.jpg/215px-Eubalaena_glacialis_with_calf.jpg"},
+    {"text" => "What is in the above image? What is in the below image?"},
+    {"image" => "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1a/Elephant_Diversity.jpg/305px-Elephant_Diversity.jpg"},
+    {"text" => "What are the differences between the images?"}
+  ]
+)
+z.assistant!
+```
+
+Both string and symbol keys are supported for the hash items:
+
+```ruby
+z = OpenAI::Chat.new
+z.user(
+  [
+    {image: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Eubalaena_glacialis_with_calf.jpg/215px-Eubalaena_glacialis_with_calf.jpg"},
+    {text: "What is in the above image? What is in the below image?"},
+    {image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1a/Elephant_Diversity.jpg/305px-Elephant_Diversity.jpg"},
+    {text: "What are the differences between the images?"}
+  ]
+)
+z.assistant!
+```
+
+## Set assistant messages manually
+
+You can manually add assistant messages:
+
+```rb
+x.assistant("Greetings, good sir or madam! How dost thou fare on this fine day? Pray, tell me how I may be of service to thee.")
+```
+
+Useful if you are reconstructing old messages from a chat that has already happened.
+
+## Getting and setting messages directly
+
+- You can call `.messages` to get an array containing the conversation so far.
+- TODO: Setting `.messages` will replace the conversation with the provided array.
+
 ## TODOs
 
 - Add a `reasoning_effort` parameter.
-- Add the ability to send images.
 - Add the ability to set all messages at once, ideally with an ActiveRecord Relation.
 - Add a way to access the whole API response body (rather than just the message content).
 - Add specs.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+require "standard/rake"
+
+RSpec::Core::RakeTask.new(:spec)
+
+desc "Run standardrb and rspec tests"
+task default: [:standard, :spec]

--- a/lib/openai-chat.rb
+++ b/lib/openai-chat.rb
@@ -1,1 +1,11 @@
+# All gem dependencies
+require "mime/types"
+require "base64"
+require "json"
+require "net/http"
+require "pathname"
+require "uri"
+
+# Internal gem files
+require "openai/chat/version"
 require "openai/chat"

--- a/lib/openai/chat.rb
+++ b/lib/openai/chat.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "openai/chat/version"
-require "net/http"
-require "uri"
-require "json"
+# All dependencies are now required in the main openai-chat.rb file
 
 module OpenAI
   class Chat
@@ -19,8 +16,78 @@ module OpenAI
       messages.push({role: "system", content: content})
     end
 
-    def user(content)
-      messages.push({role: "user", content: content})
+    def user(content, image: nil, images: nil)
+      if content.is_a?(Array)
+        processed_content = content.map do |item|
+          if item.key?("image") || item.key?(:image)
+            image_value = item.fetch("image") { item.fetch(:image) }
+            {
+              type: "image_url",
+              image_url: {
+                url: process_image(image_value)
+              }
+            }
+          elsif item.key?("text") || item.key?(:text)
+            text_value = item.fetch("text") { item.fetch(:text) }
+            {
+              type: "text",
+              text: text_value
+            }
+          else
+            item
+          end
+        end
+
+        messages.push(
+          {
+            role: "user",
+            content: processed_content
+          }
+        )
+      elsif image.nil? && images.nil?
+        messages.push(
+          {
+            role: "user",
+            content: content
+          }
+        )
+      else
+        text_and_images_array = [
+          {
+            type: "text",
+            text: content
+          }
+        ]
+
+        if images && !images.empty?
+          images_array = images.map do |image|
+            {
+              type: "image_url",
+              image_url: {
+                url: process_image(image)
+              }
+            }
+          end
+
+          text_and_images_array += images_array
+        else
+          text_and_images_array.push(
+            {
+              type: "image_url",
+              image_url: {
+                url: process_image(image)
+              }
+            }
+          )
+        end
+
+        messages.push(
+          {
+            role: "user",
+            content: text_and_images_array
+          }
+        )
+      end
     end
 
     def assistant(content)
@@ -30,7 +97,7 @@ module OpenAI
     def assistant!
       request_headers_hash = {
         "Authorization" => "Bearer #{@api_token}",
-        "content-type" => "application/json",
+        "content-type" => "application/json"
       }
 
       response_format = if schema.nil?
@@ -70,6 +137,74 @@ module OpenAI
 
     def inspect
       "#<#{self.class.name} @messages=#{messages.inspect} @model=#{@model.inspect} @schema=#{@schema.inspect}>"
+    end
+
+    private
+
+    # Custom exception class for input classification errors.
+    class InputClassificationError < StandardError; end
+
+    def classify_obj(obj)
+      if obj.is_a?(String)
+        # Attempt to parse as a URL.
+        begin
+          uri = URI.parse(obj)
+          if uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+            return :url
+          end
+        rescue URI::InvalidURIError
+          # Not a valid URL; continue to check if it's a file path.
+        end
+
+        # Check if the string represents a local file path (must exist on disk).
+        if File.exist?(obj)
+          :file_path
+        else
+          raise InputClassificationError,
+            "String provided is neither a valid URL (must start with http:// or https://) nor an existing file path on disk. Received value: #{obj.inspect}"
+        end
+      elsif obj.respond_to?(:read)
+        # For non-String objects, check if it behaves like a file.
+        :file_like
+      else
+        raise InputClassificationError,
+          "Object provided is neither a String nor file-like (missing :read method). Received value: #{obj.inspect}"
+      end
+    end
+
+    def process_image(obj)
+      case classify_obj(obj)
+      when :url
+        obj
+      when :file_path
+        file_path = obj
+
+        mime_type = MIME::Types.type_for(file_path).first.to_s
+
+        image_data = File.binread(file_path)
+
+        base64_string = Base64.strict_encode64(image_data)
+
+        "data:#{mime_type};base64,#{base64_string}"
+      when :file_like
+        filename = if obj.respond_to?(:path)
+          obj.path
+        elsif obj.respond_to?(:original_filename)
+          obj.original_filename
+        else
+          "unknown"
+        end
+
+        mime_type = MIME::Types.type_for(filename).first.to_s
+        mime_type = "image/jpeg" if mime_type.empty?
+
+        image_data = obj.read
+        obj.rewind if obj.respond_to?(:rewind)
+
+        base64_string = Base64.strict_encode64(image_data)
+
+        "data:#{mime_type};base64,#{base64_string}"
+      end
     end
   end
 end

--- a/lib/openai/chat/version.rb
+++ b/lib/openai/chat/version.rb
@@ -2,6 +2,6 @@
 
 module OpenAI
   class Chat
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end

--- a/openai_chat.gemspec
+++ b/openai_chat.gemspec
@@ -31,8 +31,16 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  # Register dependencies of the gem
+  spec.add_runtime_dependency "mime-types", "~> 3.0"
+
+  # Development dependencies
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.12"
+  spec.add_development_dependency "factory_bot", "~> 6.2"
+  spec.add_development_dependency "webmock", "~> 3.18"
+  spec.add_development_dependency "vcr", "~> 6.1"
+  spec.add_development_dependency "standard", "~> 1.32"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/spec/factories/chats.rb
+++ b/spec/factories/chats.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :chat, class: OpenAI::Chat do
+    api_token { "dummy_token" }
+
+    initialize_with { new(api_token: api_token) }
+  end
+end

--- a/spec/fixtures/test_image.jpg
+++ b/spec/fixtures/test_image.jpg
@@ -1,0 +1,1 @@
+This is a test image file

--- a/spec/openai/chat/image_support_spec.rb
+++ b/spec/openai/chat/image_support_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe OpenAI::Chat, "image support" do
+  let(:test_image_path) { File.join(File.dirname(__FILE__), "../../fixtures/test_image.jpg") }
+  let(:test_image_url) { "https://example.com/image.jpg" }
+  let(:chat) { build(:chat) }
+
+  describe "#process_image" do
+    context "with a URL" do
+      it "returns the URL unchanged" do
+        result = chat.send(:process_image, test_image_url)
+        expect(result).to eq(test_image_url)
+      end
+    end
+
+    context "with a file path" do
+      it "converts the file to a base64 data URI" do
+        result = chat.send(:process_image, test_image_path)
+
+        expect(result).to start_with("data:image/jpeg;base64,")
+
+        # Decode the base64 data and verify it matches the original file
+        base64_data = result.split(",").last
+        decoded_data = Base64.strict_decode64(base64_data)
+
+        expect(decoded_data).to eq(File.binread(test_image_path))
+      end
+    end
+
+    context "with a file-like object" do
+      it "converts the file content to a base64 data URI" do
+        file = File.open(test_image_path)
+        result = chat.send(:process_image, file)
+
+        expect(result).to start_with("data:image/jpeg;base64,")
+
+        # Decode the base64 data and verify it matches the original file
+        base64_data = result.split(",").last
+        decoded_data = Base64.strict_decode64(base64_data)
+
+        expect(decoded_data).to eq(File.binread(test_image_path))
+
+        # Check that the file pointer has been reset
+        expect(file.pos).to eq(0)
+
+        file.close
+      end
+
+      it "handles StringIO objects" do
+        content = File.binread(test_image_path)
+        string_io = StringIO.new(content)
+
+        result = chat.send(:process_image, string_io)
+
+        expect(result).to start_with("data:image/jpeg;base64,")
+
+        # Decode the base64 data and verify it matches the original content
+        base64_data = result.split(",").last
+        decoded_data = Base64.strict_decode64(base64_data)
+
+        expect(decoded_data).to eq(content)
+      end
+    end
+  end
+
+  describe "#user" do
+    context "with a single image" do
+      it "formats the message correctly with an image" do
+        chat.user("Test with image", image: test_image_path)
+
+        last_message = chat.messages.last
+        expect(last_message[:role]).to eq("user")
+        expect(last_message[:content]).to be_an(Array)
+        expect(last_message[:content].length).to eq(2)
+
+        # Text content
+        expect(last_message[:content][0][:type]).to eq("text")
+        expect(last_message[:content][0][:text]).to eq("Test with image")
+
+        # Image content
+        expect(last_message[:content][1][:type]).to eq("image_url")
+        expect(last_message[:content][1][:image_url][:url]).to start_with("data:image/jpeg;base64,")
+      end
+
+      it "formats the message correctly with an image URL" do
+        chat.user("Test with image URL", image: test_image_url)
+
+        last_message = chat.messages.last
+        expect(last_message[:role]).to eq("user")
+        expect(last_message[:content]).to be_an(Array)
+
+        # Image content
+        expect(last_message[:content][1][:type]).to eq("image_url")
+        expect(last_message[:content][1][:image_url][:url]).to eq(test_image_url)
+      end
+    end
+
+    context "with multiple images" do
+      it "formats the message correctly with multiple images" do
+        chat.user("Test with multiple images", images: [test_image_path, test_image_url])
+
+        last_message = chat.messages.last
+        expect(last_message[:role]).to eq("user")
+        expect(last_message[:content]).to be_an(Array)
+        expect(last_message[:content].length).to eq(3) # Text + 2 images
+
+        # Text content
+        expect(last_message[:content][0][:type]).to eq("text")
+        expect(last_message[:content][0][:text]).to eq("Test with multiple images")
+
+        # First image (file path)
+        expect(last_message[:content][1][:type]).to eq("image_url")
+        expect(last_message[:content][1][:image_url][:url]).to start_with("data:image/jpeg;base64,")
+
+        # Second image (URL)
+        expect(last_message[:content][2][:type]).to eq("image_url")
+        expect(last_message[:content][2][:image_url][:url]).to eq(test_image_url)
+      end
+    end
+
+    context "with direct array content" do
+      it "uses the array as is when passed directly" do
+        custom_content = [
+          {type: "text", text: "Custom message with direct array"},
+          {
+            type: "image_url",
+            image_url: {
+              url: test_image_url,
+              detail: "high"
+            }
+          }
+        ]
+
+        chat.user(custom_content)
+
+        last_message = chat.messages.last
+        expect(last_message[:role]).to eq("user")
+        expect(last_message[:content]).to eq(custom_content)
+        expect(last_message[:content]).to be_an(Array)
+        expect(last_message[:content].length).to eq(2)
+
+        # Image content with custom parameters
+        expect(last_message[:content][1][:type]).to eq("image_url")
+        expect(last_message[:content][1][:image_url][:url]).to eq(test_image_url)
+        expect(last_message[:content][1][:image_url][:detail]).to eq("high")
+      end
+
+      it "processes simplified image/text format correctly" do
+        simplified_content = [
+          {"text" => "A message with simplified format"},
+          {"image" => test_image_path},
+          {"image" => test_image_url}
+        ]
+
+        chat.user(simplified_content)
+
+        last_message = chat.messages.last
+        expect(last_message[:role]).to eq("user")
+        expect(last_message[:content]).to be_an(Array)
+        expect(last_message[:content].length).to eq(3)
+
+        # Text content
+        expect(last_message[:content][0][:type]).to eq("text")
+        expect(last_message[:content][0][:text]).to eq("A message with simplified format")
+
+        # First image (file path)
+        expect(last_message[:content][1][:type]).to eq("image_url")
+        expect(last_message[:content][1][:image_url][:url]).to start_with("data:image/jpeg;base64,")
+
+        # Second image (URL)
+        expect(last_message[:content][2][:type]).to eq("image_url")
+        expect(last_message[:content][2][:image_url][:url]).to eq(test_image_url)
+      end
+    end
+  end
+
+  describe "#classify_obj" do
+    it "classifies URLs correctly" do
+      result = chat.send(:classify_obj, "https://example.com/image.jpg")
+      expect(result).to eq(:url)
+    end
+
+    it "classifies file paths correctly" do
+      result = chat.send(:classify_obj, test_image_path)
+      expect(result).to eq(:file_path)
+    end
+
+    it "classifies file-like objects correctly" do
+      file = File.open(test_image_path)
+      result = chat.send(:classify_obj, file)
+      expect(result).to eq(:file_like)
+      file.close
+    end
+
+    it "raises an error for non-existent file paths" do
+      expect {
+        chat.send(:classify_obj, "/path/to/nonexistent/file.jpg")
+      }.to raise_error(OpenAI::Chat::InputClassificationError)
+    end
+
+    it "raises an error for objects that don't respond to read" do
+      expect {
+        chat.send(:classify_obj, Object.new)
+      }.to raise_error(OpenAI::Chat::InputClassificationError)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "openai-chat"
+require "webmock/rspec"
+require "factory_bot"
+require "vcr"
+
+# Load support files
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
+
+# Configure VCR
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/vcr_cassettes"
+  config.hook_into :webmock
+  config.configure_rspec_metadata!
+
+  # Filter sensitive data
+  config.filter_sensitive_data("<OPENAI_TOKEN>") do |interaction|
+    ENV["OPENAI_TOKEN"] || "dummy_token"
+  end
+end
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  # Include FactoryBot methods
+  config.include FactoryBot::Syntax::Methods
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
+  # Run VCR for all specs
+  config.around(:each) do |example|
+    vcr_tag = example.metadata[:vcr]
+
+    if vcr_tag
+      cassette_name = (vcr_tag == true) ? example.full_description : vcr_tag
+      VCR.use_cassette(cassette_name, record: :once) do
+        example.run
+      end
+    else
+      example.run
+    end
+  end
+end
+
+# Create fixture directory if it doesn't exist
+FileUtils.mkdir_p("spec/fixtures") unless Dir.exist?("spec/fixtures")

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
+  config.before(:suite) do
+    FactoryBot.find_definitions
+  end
+end


### PR DESCRIPTION
Resolves #6

To test, in a console (can use [this repo](https://github.com/raghubetina/openai-chat-6-rb-support-images), which has images already in `public/`):

```ruby
x = OpenAI::Chat.new
x.user("What's in this image?", image: Rails.root.join("public", "1.png"))
x.assistant!

y = OpenAI::Chat.new
y.user("What's in these images?", images: [Rails.root.join("public", "1.png"), Rails.root.join("public", "2.png")])
y.assistant!

z = OpenAI::Chat.new
z.user(
  [
    {image:"https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Eubalaena_glacialis_with_calf.jpg/215px-Eubalaena_glacialis_with_calf.jpg"},
    {text: "What is in the above image? What is in the below image?"},
    {image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1a/Elephant_Diversity.jpg/305px-Elephant_Diversity.jpg"},
    {text: "What are the differences between the images?"}
  ]
)
z.assistant!
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds image support to `OpenAI::Chat`, allowing users to include images in messages via URLs, file paths, or file-like objects, with tests and documentation updates.
> 
>   - **Behavior**:
>     - Adds support for images in `OpenAI::Chat` via `user()` method with `image` or `images` parameters.
>     - Supports image inputs as URLs, file paths, and file-like objects.
>     - Allows mixing text and images in a single message.
>   - **Functions**:
>     - `process_image()` in `chat.rb` converts images to base64 data URIs.
>     - `classify_obj()` in `chat.rb` classifies input as URL, file path, or file-like object.
>   - **Testing**:
>     - Adds `image_support_spec.rb` for testing image processing and message formatting.
>     - Uses `FactoryBot`, `WebMock`, and `VCR` for testing setup in `spec_helper.rb`.
>   - **Misc**:
>     - Updates `README.md` with image usage examples.
>     - Adds dependencies: `mime-types`, `rspec`, `factory_bot`, `webmock`, `vcr`, `standard` in `gemspec`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fopenai-chat&utm_source=github&utm_medium=referral)<sup> for ff9f64c068762a5e494b03c6dc1cbf322bca35d6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->